### PR TITLE
feat: プロフィール/キャリア情報を日本語で詳細化し works を復旧

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.claude/
 # Logs
 logs
 *.log

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,7 +1,30 @@
 /**
- * Implement Gatsby's Node APIs in this file.
+ * gatsby-source-github-api が読み込まれない場合 (GITHUB_API_TOKEN 未設定時) でも
+ * works ページの GraphQL クエリ (`githubData`) がビルドエラーにならないよう、
+ * スキーマを常に定義しておく。
  *
- * See: https://www.gatsbyjs.com/docs/node-apis/
+ * プラグイン有効時は実データが流れ込み、無効時は githubData が null を返す。
  */
-
-// You can delete this file if you're not using it
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  createTypes(`
+    type GithubData implements Node {
+      data: GithubDataData
+    }
+    type GithubDataData {
+      search: GithubDataDataSearch
+    }
+    type GithubDataDataSearch {
+      edges: [GithubDataDataSearchEdges]
+    }
+    type GithubDataDataSearchEdges {
+      node: GithubDataDataSearchEdgesNode
+    }
+    type GithubDataDataSearchEdgesNode {
+      id: String
+      name: String
+      description: String
+      url: String
+    }
+  `)
+}

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,15 +1,23 @@
 import React from "react"
+import { FiArrowUpRight } from "react-icons/fi"
 
 import Layout from "../components/layout"
 import { SEO } from "../components/SEO"
 
 // キャリアタイムラインのデータ。順序は新しい順
+type CareerLink = {
+  label: string
+  href: string
+}
+
 type Career = {
   period: string
-  role: string
   company: string
-  href: string
-  note?: string
+  companyHref: string
+  department: string
+  role: string
+  note: string
+  links?: CareerLink[]
   accent: "cyan" | "magenta" | "violet"
   current?: boolean
 }
@@ -17,27 +25,47 @@ type Career = {
 const CAREERS: Career[] = [
   {
     period: "2023 — now",
-    role: "Server Side Engineer",
-    company: "IRIAM Inc.",
-    href: "https://www.live.iriam.com/company",
-    note: "Live streaming platform for vtubers.",
+    company: "IRIAM inc.",
+    companyHref: "https://www.live.iriam.com",
+    department:
+      "IRIAMプラットフォーム事業部 プロダクト開発部 エンジニアリング第一グループ",
+    role: "エンジニアリングマネージャー",
+    note: "新感覚VTuber配信アプリ「IRIAM」における機能開発チームのマネージャー。PdMやデザイナーと仮説に対して要求分析・要件定義から行い、その検証をアジャイルに進めていくチームの運営・マネジメント・開発を担当。自身も設計や実装を行うプレイングマネージャー。",
+    links: [
+      {
+        label: "インタビュー記事",
+        href: "https://fullswing.dena.com/archives/100143/",
+      },
+      {
+        label: "podcast",
+        href: "https://podcasts.apple.com/jp/podcast/134-%E8%87%AA%E5%88%86%E3%81%AE%E4%BA%BA%E7%94%9F%E3%81%AF%E3%82%BD%E3%83%95%E3%83%88%E3%82%A6%E3%82%A7%E3%82%A2%E3%81%A7%E5%A4%89%E3%81%88%E3%82%89%E3%82%8C%E3%82%8B-%E3%81%A8%E7%9F%A5%E3%81%A3%E3%81%A6-%E3%82%A8%E3%83%B3%E3%82%B8%E3%83%8B%E3%82%A2%E3%82%92%E7%9B%AE%E6%8C%87%E3%81%99-dena-%E3%81%8A%E3%81%A7%E3%82%93/id1653563200?i=1000734427012",
+      },
+    ],
     accent: "cyan",
     current: true,
   },
   {
     period: "2021 — 2023",
-    role: "Infra Engineer / SRE",
     company: "DeNA Co., Ltd.",
-    href: "https://dena.com/",
-    note: "Cloud infrastructure & reliability engineering.",
+    companyHref: "https://dena.com/",
+    department: "IT本部 IT基盤部",
+    role: "インフラエンジニア / SRE",
+    note: "ライブ配信サービスやその他エンタメサービスのインフラ基盤(AWSがメイン)の保守運用、改善業務を担当。コスト削減の提案・コンサルティングや、マルチプラットフォーム化に向けたR&Dなども行う。",
+    links: [
+      {
+        label: "ブログ記事",
+        href: "https://engineering.dena.com/blog/2022/07/aws-gameday/",
+      },
+    ],
     accent: "magenta",
   },
   {
     period: "2019 — 2021",
-    role: "Software Engineer",
     company: "Hatena Co., Ltd.",
-    href: "https://hatena.co.jp/",
-    note: "Web services for publishers and readers.",
+    companyHref: "https://hatena.co.jp/",
+    department: "サービスプラットフォーム事業部",
+    role: "ソフトウェアエンジニア",
+    note: "社内サービス基盤や、メイン以外のプロダクト(社内ツールを含む)の開発・保守運用を担当。",
     accent: "violet",
   },
 ]
@@ -67,55 +95,6 @@ const AboutPage: React.FC = () => {
             <span className="text-bone-600">/ about</span>
           </div>
 
-          {/* ヒーロー: バイオグラフィ */}
-          <section className="mt-8 grid grid-cols-1 lg:grid-cols-12 gap-10">
-            <div className="lg:col-span-7">
-              <h1 className="font-display text-[clamp(3rem,8vw,6rem)] leading-[0.95] tracking-tight text-bone-50 text-glow-soft animate-fade-up">
-                Engineer,
-                <br />
-                <span className="italic text-gradient-neon">always learning.</span>
-              </h1>
-              <p
-                className="mt-8 max-w-xl font-mono text-sm sm:text-base leading-relaxed text-bone-300 animate-fade-up"
-                style={{ animationDelay: "150ms" }}
-              >
-                Hi, I&apos;m Tetsuya — known online as{" "}
-                <span className="text-bone-100">odmishien</span>. I build &amp;
-                operate backend systems for products that need to stay up at
-                scale. I care about reliability, observability, and writing code
-                that the next person on call can actually read.
-              </p>
-            </div>
-
-            {/* 右: メタ情報 (mono の表) */}
-            <aside
-              className="lg:col-span-5 glass rounded-sm p-6 sm:p-7 animate-fade-up"
-              style={{ animationDelay: "240ms" }}
-            >
-              <div className="font-mono text-[10px] uppercase tracking-widest text-bone-500">
-                profile / system info
-              </div>
-              <dl className="mt-5 space-y-3 font-mono text-sm">
-                {[
-                  ["alias", "@odmishien"],
-                  ["role", "backend · sre"],
-                  ["loc", "Tokyo, JP"],
-                  ["status", "online"],
-                ].map(([k, v]) => (
-                  <div
-                    key={k}
-                    className="flex items-center justify-between gap-4 border-b border-dashed border-white/10 pb-2 last:border-0 last:pb-0"
-                  >
-                    <dt className="text-bone-600 uppercase tracking-widest text-[11px]">
-                      {k}
-                    </dt>
-                    <dd className="text-bone-100">{v}</dd>
-                  </div>
-                ))}
-              </dl>
-            </aside>
-          </section>
-
           {/* キャリアタイムライン */}
           <section className="mt-20 sm:mt-28">
             <header className="flex items-end justify-between gap-4 flex-wrap">
@@ -123,7 +102,7 @@ const AboutPage: React.FC = () => {
                 Careers
               </h2>
               <span className="font-mono text-[10px] uppercase tracking-widest text-bone-500">
-                0{CAREERS.length} entries
+                0{CAREERS.length} careers
               </span>
             </header>
             <div className="hairline mt-4" />
@@ -138,7 +117,7 @@ const AboutPage: React.FC = () => {
               {CAREERS.map((c, idx) => (
                 <li
                   key={c.company}
-                  className="relative pl-8 sm:pl-12 pb-12 last:pb-0 animate-fade-up"
+                  className="relative pl-8 sm:pl-12 pb-14 last:pb-0 animate-fade-up"
                   style={{ animationDelay: `${idx * 120}ms` }}
                 >
                   {/* 接続点 */}
@@ -153,24 +132,22 @@ const AboutPage: React.FC = () => {
                     />
                   )}
 
-                  <div className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-2">
-                    <div className="font-mono text-[11px] sm:text-xs uppercase tracking-widest text-bone-500">
-                      <span className={ACCENT_TEXT[c.accent]}>●</span>{" "}
-                      {c.period}
-                      {c.current && (
-                        <span className="ml-3 inline-flex items-center gap-1 text-neon-cyan">
-                          <span className="h-1 w-1 rounded-full bg-neon-cyan animate-pulse-slow" />
-                          current
-                        </span>
-                      )}
-                    </div>
+                  {/* 期間 + current バッジ */}
+                  <div className="font-mono text-[11px] sm:text-xs uppercase tracking-widest text-bone-500">
+                    <span className={ACCENT_TEXT[c.accent]}>●</span>{" "}
+                    {c.period}
+                    {c.current && (
+                      <span className="ml-3 inline-flex items-center gap-1 text-neon-cyan">
+                        <span className="h-1 w-1 rounded-full bg-neon-cyan animate-pulse-slow" />
+                        current
+                      </span>
+                    )}
                   </div>
 
+                  {/* 会社名 */}
                   <h3 className="mt-3 font-display text-3xl sm:text-4xl leading-tight text-bone-50">
-                    {c.role}{" "}
-                    <span className="text-bone-500">@</span>{" "}
                     <a
-                      href={c.href}
+                      href={c.companyHref}
                       target="_blank"
                       rel="noreferrer"
                       className={`link-underline ${ACCENT_TEXT[c.accent]}`}
@@ -178,10 +155,51 @@ const AboutPage: React.FC = () => {
                       {c.company}
                     </a>
                   </h3>
-                  {c.note && (
-                    <p className="mt-3 font-mono text-sm text-bone-300 max-w-2xl">
-                      {c.note}
-                    </p>
+
+                  {/* 部署 / 役職 */}
+                  <div className="mt-3 font-mono text-xs sm:text-sm text-bone-300 space-y-1">
+                    <div className="flex flex-wrap items-baseline gap-x-3">
+                      <span className="text-bone-600 uppercase tracking-widest text-[10px] whitespace-nowrap">
+                        dept
+                      </span>
+                      <span>{c.department}</span>
+                    </div>
+                    <div className="flex flex-wrap items-baseline gap-x-3">
+                      <span className="text-bone-600 uppercase tracking-widest text-[10px] whitespace-nowrap">
+                        role
+                      </span>
+                      <span className="text-bone-100">{c.role}</span>
+                    </div>
+                  </div>
+
+                  {/* 業務内容 */}
+                  <p className="mt-4 font-mono text-sm leading-loose text-bone-300 max-w-2xl">
+                    {c.note}
+                  </p>
+
+                  {/* 関連リンク */}
+                  {c.links && c.links.length > 0 && (
+                    <ul className="mt-5 flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-xs">
+                      <li className="text-bone-600 uppercase tracking-widest text-[10px]">
+                        links
+                      </li>
+                      {c.links.map(l => (
+                        <li key={l.href}>
+                          <a
+                            href={l.href}
+                            target="_blank"
+                            rel="noreferrer"
+                            className={`group inline-flex items-center gap-1 ${ACCENT_TEXT[c.accent]} hover:opacity-80 transition-opacity`}
+                          >
+                            <span className="link-underline">{l.label}</span>
+                            <FiArrowUpRight
+                              className="transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+                              aria-hidden
+                            />
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
                   )}
                 </li>
               ))}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -93,7 +93,7 @@ const IndexPage: React.FC = () => {
                 </div>
                 <div>
                   <span className="text-bone-600">based</span>{" "}
-                  <span className="text-bone-100">Tokyo, JP</span>
+                  <span className="text-bone-100">Osaka, JP</span>
                 </div>
               </div>
             </div>
@@ -104,27 +104,31 @@ const IndexPage: React.FC = () => {
                 <span className="block text-bone-50 text-glow-soft">
                   odmishien
                 </span>
-                <span className="block text-gradient-neon italic">
-                  &mdash; observatory
-                </span>
               </h1>
 
               <p
-                className="mt-8 max-w-xl font-mono text-sm sm:text-base leading-relaxed text-bone-300 animate-fade-up"
+                className="mt-8 max-w-2xl font-mono text-sm sm:text-base leading-loose text-bone-300 animate-fade-up"
                 style={{ animationDelay: "200ms" }}
               >
-                Backend & SRE engineer building reliable, observable systems.
-                <br className="hidden sm:block" />
-                Currently at{" "}
+                2021年に
                 <a
-                  href="https://www.live.iriam.com/company"
+                  href="https://dena.com/"
                   target="_blank"
                   rel="noreferrer"
                   className="link-underline text-neon-cyan"
                 >
-                  IRIAM Inc.
+                  株式会社ディー・エヌ・エー
                 </a>
-                — previously Hatena & DeNA.
+                にエンジニア職として新卒入社。入社後は社内サービスのクラウドインフラ基盤を管理する部署に配属。主にライブ配信サービスやその他エンタメサービスのSREとして、インフラ基盤管理・開発、障害対応、コスト削減などに取り組む。2023年2月に部署を異動し、子会社である
+                <a
+                  href="https://www.live.iriam.com"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="link-underline text-neon-cyan"
+                >
+                  株式会社IRIAM
+                </a>
+                へ出向。現在はサービス内におけるユーザーマッチング課題に対して機能開発を行うクロスファンクショナルチームにてエンジニアリングマネージャーとして奮闘中。
               </p>
             </div>
           </section>

--- a/src/pages/works.tsx
+++ b/src/pages/works.tsx
@@ -10,7 +10,7 @@ interface WorksProps {
 }
 
 const WorksPage: React.FC<WorksProps> = ({ data }) => {
-  // GITHUB_API_TOKEN 未設定時は空配列 (schema に githubData が無いケースを許容)
+  // GITHUB_API_TOKEN 未設定時は githubData が null になる (gatsby-node.js でスキーマだけ常に定義)
   const repos = data?.githubData?.data?.search?.edges ?? []
 
   return (
@@ -77,22 +77,22 @@ const WorksPage: React.FC<WorksProps> = ({ data }) => {
 
 export default WorksPage
 
-// GITHUB_API_TOKEN 未設定時は githubData が schema に存在しないためコメントアウト
-// export const query = graphql`
-//   query Works {
-//     githubData {
-//       data {
-//         search {
-//           edges {
-//             node {
-//               id
-//               name
-//               description
-//               url
-//             }
-//           }
-//         }
-//       }
-//     }
-//   }
-// `
+// スキーマは gatsby-node.js で常に定義しているため、token の有無によらずクエリは通る
+export const query = graphql`
+  query Works {
+    githubData {
+      data {
+        search {
+          edges {
+            node {
+              id
+              name
+              description
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+`

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,9 +30,29 @@ module.exports = {
       },
       fontFamily: {
         // Google Fonts は layout.tsx から読み込む
-        display: ['"Instrument Serif"', "Georgia", "serif"],
-        mono: ['"JetBrains Mono"', "ui-monospace", "Menlo", "monospace"],
-        sans: ['"JetBrains Mono"', "system-ui", "sans-serif"],
+        // 英数字 → ラテンフォント、日本語 → CJK フォントに自動でフォールバック
+        display: [
+          '"Instrument Serif"',
+          '"Hiragino Mincho ProN"',
+          '"Yu Mincho"',
+          "Georgia",
+          "serif",
+        ],
+        mono: [
+          '"JetBrains Mono"',
+          "ui-monospace",
+          "Menlo",
+          '"Hiragino Sans"',
+          '"Noto Sans JP"',
+          "sans-serif",
+        ],
+        sans: [
+          '"JetBrains Mono"',
+          "system-ui",
+          '"Hiragino Sans"',
+          '"Noto Sans JP"',
+          "sans-serif",
+        ],
       },
       letterSpacing: {
         widest: "0.32em",

--- a/types/graphql-types.d.ts
+++ b/types/graphql-types.d.ts
@@ -997,6 +997,194 @@ export type FloatQueryOperatorInput = {
   nin?: Maybe<Array<Maybe<Scalars['Float']>>>;
 };
 
+export type GithubData = Node & {
+  data?: Maybe<GithubDataData>;
+  id: Scalars['ID'];
+  parent?: Maybe<Node>;
+  children: Array<Node>;
+  internal: Internal;
+};
+
+export type GithubDataConnection = {
+  totalCount: Scalars['Int'];
+  edges: Array<GithubDataEdge>;
+  nodes: Array<GithubData>;
+  pageInfo: PageInfo;
+  distinct: Array<Scalars['String']>;
+  group: Array<GithubDataGroupConnection>;
+};
+
+
+export type GithubDataConnectionDistinctArgs = {
+  field: GithubDataFieldsEnum;
+};
+
+
+export type GithubDataConnectionGroupArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+  field: GithubDataFieldsEnum;
+};
+
+export type GithubDataData = {
+  search?: Maybe<GithubDataDataSearch>;
+};
+
+export type GithubDataDataFilterInput = {
+  search?: Maybe<GithubDataDataSearchFilterInput>;
+};
+
+export type GithubDataDataSearch = {
+  edges?: Maybe<Array<Maybe<GithubDataDataSearchEdges>>>;
+};
+
+export type GithubDataDataSearchEdges = {
+  node?: Maybe<GithubDataDataSearchEdgesNode>;
+};
+
+export type GithubDataDataSearchEdgesFilterInput = {
+  node?: Maybe<GithubDataDataSearchEdgesNodeFilterInput>;
+};
+
+export type GithubDataDataSearchEdgesFilterListInput = {
+  elemMatch?: Maybe<GithubDataDataSearchEdgesFilterInput>;
+};
+
+export type GithubDataDataSearchEdgesNode = {
+  id?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']>;
+};
+
+export type GithubDataDataSearchEdgesNodeFilterInput = {
+  id?: Maybe<StringQueryOperatorInput>;
+  name?: Maybe<StringQueryOperatorInput>;
+  description?: Maybe<StringQueryOperatorInput>;
+  url?: Maybe<StringQueryOperatorInput>;
+};
+
+export type GithubDataDataSearchFilterInput = {
+  edges?: Maybe<GithubDataDataSearchEdgesFilterListInput>;
+};
+
+export type GithubDataEdge = {
+  next?: Maybe<GithubData>;
+  node: GithubData;
+  previous?: Maybe<GithubData>;
+};
+
+export type GithubDataFieldsEnum = 
+  | 'data___search___edges'
+  | 'id'
+  | 'parent___id'
+  | 'parent___parent___id'
+  | 'parent___parent___parent___id'
+  | 'parent___parent___parent___children'
+  | 'parent___parent___children'
+  | 'parent___parent___children___id'
+  | 'parent___parent___children___children'
+  | 'parent___parent___internal___content'
+  | 'parent___parent___internal___contentDigest'
+  | 'parent___parent___internal___description'
+  | 'parent___parent___internal___fieldOwners'
+  | 'parent___parent___internal___ignoreType'
+  | 'parent___parent___internal___mediaType'
+  | 'parent___parent___internal___owner'
+  | 'parent___parent___internal___type'
+  | 'parent___children'
+  | 'parent___children___id'
+  | 'parent___children___parent___id'
+  | 'parent___children___parent___children'
+  | 'parent___children___children'
+  | 'parent___children___children___id'
+  | 'parent___children___children___children'
+  | 'parent___children___internal___content'
+  | 'parent___children___internal___contentDigest'
+  | 'parent___children___internal___description'
+  | 'parent___children___internal___fieldOwners'
+  | 'parent___children___internal___ignoreType'
+  | 'parent___children___internal___mediaType'
+  | 'parent___children___internal___owner'
+  | 'parent___children___internal___type'
+  | 'parent___internal___content'
+  | 'parent___internal___contentDigest'
+  | 'parent___internal___description'
+  | 'parent___internal___fieldOwners'
+  | 'parent___internal___ignoreType'
+  | 'parent___internal___mediaType'
+  | 'parent___internal___owner'
+  | 'parent___internal___type'
+  | 'children'
+  | 'children___id'
+  | 'children___parent___id'
+  | 'children___parent___parent___id'
+  | 'children___parent___parent___children'
+  | 'children___parent___children'
+  | 'children___parent___children___id'
+  | 'children___parent___children___children'
+  | 'children___parent___internal___content'
+  | 'children___parent___internal___contentDigest'
+  | 'children___parent___internal___description'
+  | 'children___parent___internal___fieldOwners'
+  | 'children___parent___internal___ignoreType'
+  | 'children___parent___internal___mediaType'
+  | 'children___parent___internal___owner'
+  | 'children___parent___internal___type'
+  | 'children___children'
+  | 'children___children___id'
+  | 'children___children___parent___id'
+  | 'children___children___parent___children'
+  | 'children___children___children'
+  | 'children___children___children___id'
+  | 'children___children___children___children'
+  | 'children___children___internal___content'
+  | 'children___children___internal___contentDigest'
+  | 'children___children___internal___description'
+  | 'children___children___internal___fieldOwners'
+  | 'children___children___internal___ignoreType'
+  | 'children___children___internal___mediaType'
+  | 'children___children___internal___owner'
+  | 'children___children___internal___type'
+  | 'children___internal___content'
+  | 'children___internal___contentDigest'
+  | 'children___internal___description'
+  | 'children___internal___fieldOwners'
+  | 'children___internal___ignoreType'
+  | 'children___internal___mediaType'
+  | 'children___internal___owner'
+  | 'children___internal___type'
+  | 'internal___content'
+  | 'internal___contentDigest'
+  | 'internal___description'
+  | 'internal___fieldOwners'
+  | 'internal___ignoreType'
+  | 'internal___mediaType'
+  | 'internal___owner'
+  | 'internal___type';
+
+export type GithubDataFilterInput = {
+  data?: Maybe<GithubDataDataFilterInput>;
+  id?: Maybe<StringQueryOperatorInput>;
+  parent?: Maybe<NodeFilterInput>;
+  children?: Maybe<NodeFilterListInput>;
+  internal?: Maybe<InternalFilterInput>;
+};
+
+export type GithubDataGroupConnection = {
+  totalCount: Scalars['Int'];
+  edges: Array<GithubDataEdge>;
+  nodes: Array<GithubData>;
+  pageInfo: PageInfo;
+  field: Scalars['String'];
+  fieldValue?: Maybe<Scalars['String']>;
+};
+
+export type GithubDataSortInput = {
+  fields?: Maybe<Array<Maybe<GithubDataFieldsEnum>>>;
+  order?: Maybe<Array<Maybe<SortOrderEnum>>>;
+};
+
 export type Internal = {
   content?: Maybe<Scalars['String']>;
   contentDigest: Scalars['String'];
@@ -1069,6 +1257,8 @@ export type Query = {
   allSite: SiteConnection;
   sitePage?: Maybe<SitePage>;
   allSitePage: SitePageConnection;
+  githubData?: Maybe<GithubData>;
+  allGithubData: GithubDataConnection;
   feedHatenaBlogPostsMeta?: Maybe<FeedHatenaBlogPostsMeta>;
   allFeedHatenaBlogPostsMeta: FeedHatenaBlogPostsMetaConnection;
   feedHatenaBlogPosts?: Maybe<FeedHatenaBlogPosts>;
@@ -1216,6 +1406,23 @@ export type QuerySitePageArgs = {
 export type QueryAllSitePageArgs = {
   filter?: Maybe<SitePageFilterInput>;
   sort?: Maybe<SitePageSortInput>;
+  skip?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+};
+
+
+export type QueryGithubDataArgs = {
+  data?: Maybe<GithubDataDataFilterInput>;
+  id?: Maybe<StringQueryOperatorInput>;
+  parent?: Maybe<NodeFilterInput>;
+  children?: Maybe<NodeFilterListInput>;
+  internal?: Maybe<InternalFilterInput>;
+};
+
+
+export type QueryAllGithubDataArgs = {
+  filter?: Maybe<GithubDataFilterInput>;
+  sort?: Maybe<GithubDataSortInput>;
   skip?: Maybe<Scalars['Int']>;
   limit?: Maybe<Scalars['Int']>;
 };
@@ -2188,3 +2395,8 @@ export type PostsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type PostsQuery = { allFeedHatenaBlogPosts: { edges: Array<{ node: Pick<FeedHatenaBlogPosts, 'title' | 'link' | 'pubDate'> }> } };
+
+export type WorksQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type WorksQuery = { githubData?: Maybe<{ data?: Maybe<{ search?: Maybe<{ edges?: Maybe<Array<Maybe<{ node?: Maybe<Pick<GithubDataDataSearchEdgesNode, 'id' | 'name' | 'description' | 'url'>> }>>> }> }> }> };


### PR DESCRIPTION
## Summary
- **about**: ヒーローセクションを削除し、キャリアを「部署 / 役職 / 業務内容 / 関連リンク」まで載せた日本語の詳細版に刷新
- **index**: 自己紹介文を日本語の経歴文に書き換え、拠点を `Osaka, JP` に更新
- **works**: `gatsby-node.js` で `GithubData` スキーマを常時定義し、`GITHUB_API_TOKEN` 未設定時でもクエリが通るように修正 (`works.tsx` の GraphQL クエリを復活)
- **tailwind**: `display` / `mono` / `sans` に日本語フォントのフォールバックを追加
- **.gitignore**: ローカル専用の `.claude/` を追跡対象から除外

## Test plan
- [ ] `npm run develop` で about / index / works が表示される
- [ ] `GITHUB_API_TOKEN` 未設定でも works ページがビルド・表示できる
- [ ] 日本語テキストが意図したフォント (明朝 / Sans) で表示される
- [ ] キャリアの関連リンクが新規タブで開き、アクセント色が崩れていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)